### PR TITLE
Fix data-variant attribute being corrupted if spaces were present

### DIFF
--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -4,6 +4,7 @@ import { IconButton } from "@storybook/components";
 import { API, useChannel, useStorybookApi, Story } from "@storybook/api";
 import {
   createStoryRequest,
+  escapeHtml,
   getStorybookToken,
   // getStoryNameFromArgs,
   notify,
@@ -223,8 +224,8 @@ const createStory = async (
       (key) => `${key}=${variant[key]}`
     );
 
-    const variantID = variantData.join(",") || "default";
-    const variantHTML = `<div data-variant=${variantID} data-variant-id="${variantHash}">${data.current.html}</div>`;
+    const variantID = escapeHtml(variantData.join(",") || "default");
+    const variantHTML = `<div data-variant='${variantID}' data-variant-id="${variantHash}">${data.current.html}</div>`;
     const variantCSS = data.current.css;
 
     if (variantHash === defaultVariantHash) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -47,3 +47,12 @@ export const downloadAsJSON = (data: Record<string, any>) => {
   link.click();
   document.body.removeChild(link);
 };
+
+// Source: https://stackoverflow.com/a/6234804/18342693
+export const escapeHtml = (html: string) =>
+  html
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#039;");


### PR DESCRIPTION
This PR fixes: https://app.asana.com/0/1201799769793786/1201927652469183/f

The bug was caused by the label `Chip text` that corrupted the `data-variant` attribute due to the unquoted space.

![Screenshot 2022-03-14 at 16 15 17](https://user-images.githubusercontent.com/100688209/158206537-ee038165-cc31-43de-86bc-a292590aabe7.png)

The proposed solution is to enclose the attribute between quotes and escape it to avoid problems with nested quotes (eg. `data-variant='label=That's good'`

<img width="394" alt="image" src="https://user-images.githubusercontent.com/100688209/158206743-d35760a1-54ec-4988-aa30-b68748d559ce.png">

Please let me know if you have any concerns or suggestions :)