### PR TITLE
fix: remove grid layout in exported html to prevent collapse

### DIFF
--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -277,20 +277,6 @@ const getStoryPayload = async (
     CSS += variantCSS;
   }
 
-  const gridCSS = `
-    #root{
-      display: inline-grid;
-      grid-template-columns: repeat(6, 1fr);
-      grid-template-rows: auto;
-      gap: 10px 5px;
-    }
-`;
-
-  // display the variants in a grid layout
-  if (orderedVariants.length > 1) {
-    CSS += gridCSS;
-  }
-
   const fingerprint = md5({ variants: hashArray, name: storyName });
 
   const { height, width } = data.current;


### PR DESCRIPTION
This PR removes the code that places the exported variants in a grid, which was causing some large components to collapse (such as the tabs component).
That in turn caused the generated blueprints to be collapsed as well, which is something that's probably not desirable

Before:
![image](https://user-images.githubusercontent.com/100688209/167639874-bba0f018-a9cb-4aea-83ff-3dcb17400d4b.png)


After:
![image](https://user-images.githubusercontent.com/100688209/167639836-a5e2ecce-9f80-455c-a933-4c3aab5eb9b1.png)

