### PR TITLE
feat: improve variant trimming logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ As a result, some props might be missing in the exported
 components.
 
 In the near future, we are going to provide some options to
-customise which controls should be included or excluded during
+customize which controls should be included or excluded during
 the export process.
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -11,18 +11,19 @@
 [Storybook](https://github.com/storybooks/storybook) addon that extracts the Storybook data and transforms stories into Figma components for a better design-development workflow.
 
 Learn more about the motivations and benefits in our [our blog post](https://blog.animaapp.com/design-with-your-live-code-components-7f61e99b9bf0)
-  
+
 ### Demo
+
   <div align="center">
   <img src="https://user-images.githubusercontent.com/1323193/155579455-2b9919de-41e7-4e6d-b067-12993833a172.gif" width="700px" alt="Storybook to Anima to Figma Addon"/>
   </div>
 
 ## Requirements
 
--   Storybook@>=6.0.0
--   [Anima Account](https://www.animaapp.com/figma)
--   Sign up for [Anima's beta](https://form.typeform.com/to/eNOueDoh)
--   [Anima's Figma plugin](https://www.figma.com/community/plugin/857346721138427857/Export-to-React%2C-HTML-%26-Vue-code-with-Anima)
+- Storybook@>=6.0.0
+- [Anima Account](https://www.animaapp.com/figma)
+- Sign up for [Anima's beta](https://form.typeform.com/to/eNOueDoh)
+- [Anima's Figma plugin](https://www.figma.com/community/plugin/857346721138427857/Export-to-React%2C-HTML-%26-Vue-code-with-Anima)
 
 This addon should work with any framework. If you find a case that the addon does not work, please open an issue.
 
@@ -40,9 +41,10 @@ npm install --save-dev storybook-anima
 ```js
 // .storybook/main.js
 module.exports = {
-    addons: ["storybook-anima"],
+  addons: ["storybook-anima"],
 };
 ```
+
 ### 3. Set Anima access token
 
 First get the access token from the Anima Figma plugin, or in your Anima team settings. Learn more about [how to get the token from Anima](https://www.loom.com/share/9f93c49c33824773afdb0fc4658c69e0?utm_source=github).
@@ -51,7 +53,6 @@ You can then set the access token as an environment variable called `STORYBOOK_A
 
 You can create `.env` file in your project's root folder, or you can provide the environment variable as a command line parameter when building or dynamically running Storybook.
 
-
 ```shell
 # .env
 STORYBOOK_ANIMA_TOKEN="<paste your TOKEN here>"
@@ -59,10 +60,19 @@ STORYBOOK_ANIMA_TOKEN="<paste your TOKEN here>"
 
 ## Considerations
 
-For the time being, this integration works best if the your stories composition consists of just the component itself, rather than complex stories with multiple examples or included documentation. 
+For the time being, this integration works best if the your stories composition consists of just the component itself, rather than complex stories with multiple examples or included documentation.
 
 #### In short, what you see in the Storybook story, is what you'll get in Figma.
 
+## Limits on the number of variants
+
+The addon currently limits the number of variants to a maximum of 1025 for any given story.
+As a result, some props might be missing in the exported
+components.
+
+In the near future, we are going to provide some options to
+customise which controls should be included or excluded during
+the export process.
 
 ## Development
 

--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -243,9 +243,9 @@ const getStoryPayload = async (
   if (hadTrimmedVariants) {
     console.warn(
       `Unable to export all controls for story: '${storyName}' as the resulting number of variants would have been too high. ` +
-        `You can solve this problem by explicitly specifying which props should be exported in the story definition files. Please see: TODO`
+        `You can solve this problem by explicitly specifying which props should be exported in the story definition files. ` +
+        `For more information, see: https://github.com/AnimaApp/storybook-anima#limits-on-the-number-of-variants`
     );
-    // TODO: add the actual documentation link once we support such property
   }
 
   let defaultArgsQuery = "";

--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -242,7 +242,7 @@ const getStoryPayload = async (
 
   if (hadTrimmedVariants) {
     console.warn(
-      `unable to export all props for story: ${storyName}, as the resulting number of variants would have been too high. ` +
+      `Unable to export all controls for story: '${storyName}' as the resulting number of variants would have been too high. ` +
         `You can solve this problem by explicitly specifying which props should be exported in the story definition files. Please see: TODO`
     );
     // TODO: add the actual documentation link once we support such property

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -120,8 +120,8 @@ const Banner: React.FC<IProps> = (props) => {
                     fontSize: "10px",
                   }}
                 >
-                  (some props have been excluded for performance reasons, please
-                  see the console for more information)
+                  (Some controls have been excluded for performance reasons,
+                  please see the console for more information)
                 </span>
               )}
               <span

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -15,7 +15,13 @@ interface IProps {
 const Banner: React.FC<IProps> = (props) => {
   const defaultExportStatus = { current: 1, total: 1, storyName: "Story" };
   const [isOpen, setIsOpen] = useState(false);
-  const [progress, setProgress] = useState(defaultExportStatus);
+  const [progress, setProgress] =
+    useState<{
+      current: number;
+      total: number;
+      storyName: string;
+      hadTrimmedVariants?: boolean;
+    }>(defaultExportStatus);
 
   const transitions = {
     entering: { opacity: 0 },
@@ -106,6 +112,18 @@ const Banner: React.FC<IProps> = (props) => {
               >
                 Exporting {progress.storyName}
               </span>
+              {progress.hadTrimmedVariants && (
+                <span
+                  style={{
+                    marginBottom: "5px",
+                    fontWeight: 600,
+                    fontSize: "10px",
+                  }}
+                >
+                  (some props have been excluded for performance reasons, please
+                  see the console for more information)
+                </span>
+              )}
               <span
                 style={{
                   marginBottom: "5px",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,7 @@
 export const API_URL =
   localStorage.getItem("api_url") || "https://api.animaapp.com";
 export const PARAM_KEY = "export-stories";
-export const VARIANTS_COUNT_LIMIT = 1000;
+export const VARIANTS_COUNT_LIMIT = 1025;
 export const EVENT_CODE_RECEIVED = "EVENT_CODE_RECEIVED";
 export const IFRAME_RENDERER_CLICK = "IFRAME_RENDERER_CLICK";
 export const ANIMA_ROOT_ID = "ANIMA_ROOT_ID";


### PR DESCRIPTION
This PR slightly improves the variant trimming logic to:
* Figure out whats the max number of controls that generate N variants, with N < 1025
* Generate the variants based on that
* Show a warning if some controls trimming was necessary to keep the number of variants small