### PR TITLE
fix: fix bug that caused crash on some components and improve text

### DIFF
--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -164,6 +164,9 @@ const getTopNVariantsWithinLimit = (
   hadTrimmedVariants: boolean
 ] => {
   const argTypeEntries = Object.entries(argTypes);
+  if (argTypeEntries.length === 0) {
+    return [...getVariants(story, argTypes), false];
+  }
 
   let currentArgs: ArgTypes = {};
   let previousVariants: [Record<string, any>[], boolean];
@@ -181,7 +184,12 @@ const getTopNVariantsWithinLimit = (
     }
   }
 
-  return [...previousVariants, hadTrimmedVariants];
+  if (hadTrimmedVariants) {
+    // If we had to trim variants, then we want the component to be classified as complex
+    return [previousVariants[0], true, hadTrimmedVariants];
+  } else {
+    return [...previousVariants, hadTrimmedVariants];
+  }
 };
 
 const doExport = async (

--- a/src/components/banner.tsx
+++ b/src/components/banner.tsx
@@ -112,18 +112,6 @@ const Banner: React.FC<IProps> = (props) => {
               >
                 Exporting {progress.storyName}
               </span>
-              {progress.hadTrimmedVariants && (
-                <span
-                  style={{
-                    marginBottom: "5px",
-                    fontWeight: 600,
-                    fontSize: "10px",
-                  }}
-                >
-                  (Some controls have been excluded for performance reasons,
-                  please see the console for more information)
-                </span>
-              )}
               <span
                 style={{
                   marginBottom: "5px",
@@ -133,6 +121,20 @@ const Banner: React.FC<IProps> = (props) => {
               >
                 {progress.current} / {progress.total} variants exported
               </span>
+
+              {progress.hadTrimmedVariants && (
+                <span
+                  style={{
+                    marginBottom: "5px",
+                    fontWeight: 600,
+                    fontSize: "10px",
+                  }}
+                >
+                  *Some controls were skipped to reduce variants in Figma*
+                  <br />
+                  View the addon guidelines for more details
+                </span>
+              )}
             </div>
           </div>
         </div>

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -8,7 +8,7 @@ const GLOBAL_STYLES = `
   z-index: 998;
   bottom: 20px;
   right: 20px;
-  height: 65px;
+  min-height: 65px;
   min-Width: 200px;
   box-shadow: inset 0px 0px 0px 2px #505050;
   border-radius: 5px;


### PR DESCRIPTION
This PR fixes a bug that caused some components to not being exported correctly (when they didn't have args) + changes the notification text when variant trimming is enabled:

![Screenshot 2022-05-30 at 10 36 14](https://user-images.githubusercontent.com/100688209/170952986-ff554488-c8fe-4ad8-9796-07fce88c87fe.png)
![Screenshot 2022-05-30 at 10 32 34](https://user-images.githubusercontent.com/100688209/170952993-eca6222f-6a59-4ed4-8d90-482fe7d2334f.png)

Let me know if you have any concerns :)