### PR TITLE
feat: remove async promises await

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@storybook/docs-tools": "^6.5.0",
     "@storybook/source-loader": "^6.5.0",
     "babel-storybook-anima": "0.1.1",
+    "fast-deep-equal": "^3.1.3",
     "flat": "^5.0.2",
     "lodash": "^4.17.21",
     "mitt": "^3.0.0",

--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -10,11 +10,9 @@ import {
   useStorybookState,
   State,
   useArgTypes,
-  useArgs,
   ArgTypes,
 } from "@storybook/api";
 import { Args } from "@storybook/addons";
-import { STORY_RENDERED, UPDATE_QUERY_PARAMS } from "@storybook/core-events";
 import { Popover } from "react-tiny-popover";
 import {
   get,
@@ -31,9 +29,9 @@ import {
 import {
   createStoryRequest,
   escapeHtml,
-  getEventHandlerAsPromise,
   getStorybookToken,
   isDocsStory,
+  nextTick,
   notify,
   StoryPayload,
   StoryVariant,
@@ -51,6 +49,7 @@ import {
   VARIANTS_COUNT_LIMIT,
 } from "./constants";
 import { choice, runSeed } from "./utils";
+import { buildArgsParam } from "./utils/argsQuery";
 
 interface SProps {}
 
@@ -192,6 +191,30 @@ const getTopNVariantsWithinLimit = (
   }
 };
 
+// Extract the properties we support from the initial args so that
+// the query building process can ignore them.
+const getSupportedInitialArgs = (argTypes: ArgTypes, initialArgs: any) => {
+  if (!initialArgs || !argTypes) {
+    return {};
+  }
+
+  const supportedArgs = {};
+
+  for (const [argName, arg] of Object.entries(argTypes)) {
+    const argType = getArgType(arg);
+    const initialArgValue = initialArgs[argName];
+
+    if (
+      SUPPORTED_ARG_TYPES.includes(argType) &&
+      initialArgValue !== undefined
+    ) {
+      supportedArgs[argName] = initialArgValue;
+    }
+  }
+
+  return supportedArgs;
+};
+
 const doExport = async (
   api: API,
   state: State,
@@ -228,22 +251,16 @@ const doExport = async (
 
 const getStoryPayload = async (
   api: API,
-  args: React.MutableRefObject<{}>,
   argTypes: ArgTypes
 ): Promise<StoryPayload> => {
   const story = api.getCurrentStoryData() as Story;
 
   const storyName = story.name;
   const storyId = story.id;
-
-  const [handleStoryRender, getStoryRenderPromise] = getEventHandlerAsPromise();
-
-  const [handleUpdateQueryParams, getUpdateQueryParams] =
-    getEventHandlerAsPromise();
-
-  api.on(STORY_RENDERED, handleStoryRender);
-
-  api.on(UPDATE_QUERY_PARAMS, handleUpdateQueryParams);
+  const supportedInitialArgs = getSupportedInitialArgs(
+    story.argTypes,
+    story.initialArgs
+  );
 
   const [variants, isUsingEditor, hadTrimmedVariants] =
     getTopNVariantsWithinLimit(story, argTypes);
@@ -286,38 +303,34 @@ const getStoryPayload = async (
         return Object.assign(cur, { [key]: variant[key] });
       }, {});
 
-    const storyRenderPromise =
-      getStoryRenderPromise() as unknown as Promise<string>;
-
-    const getUpdateQueryParamsPromise =
-      getUpdateQueryParams() as unknown as Promise<{ args: {} }>;
-
-    api.updateStoryArgs(story, variant);
-
-    await Promise.all([getUpdateQueryParamsPromise, storyRenderPromise]);
-
     const snippetCode = "";
     const snippetCodeAsBase64 = snippetCode ? window.btoa(snippetCode) : "";
 
-    window.parent.postMessage(
-      {
-        action: EXPORT_PROGRESS,
-        data: {
-          current: i + 1,
-          total: uniqueVariants.length,
-          storyName,
-          hadTrimmedVariants,
+    // Every once in a while notify the progress
+    if (i % 50 === 0 || i === uniqueVariants.length - 1) {
+      window.parent.postMessage(
+        {
+          action: EXPORT_PROGRESS,
+          data: {
+            current: i + 1,
+            total: uniqueVariants.length,
+            storyName,
+            hadTrimmedVariants,
+          },
+          source: "anima",
         },
-        source: "anima",
-      },
-      "*"
-    );
+        "*"
+      );
+      // Wait for the UI to update
+      await nextTick();
+    }
 
     const variantData = Object.keys(variant).map(
       (key) => `${key}=${variant[key]}`
     );
     const variantID = escapeHtml(variantData.join(",") || "default");
-    const query = window.location.search;
+    const serializedArgs = buildArgsParam(supportedInitialArgs, variant);
+    const query = `?path=/story/${story.id}&args=${serializedArgs}`;
 
     if (i === 0) {
       is_default = true;
@@ -328,7 +341,7 @@ const getStoryPayload = async (
       html_url: `iframe.html${query}`,
       description: snippetCodeAsBase64,
       variant_id: variantID,
-      args: args.current,
+      args: variant,
       is_default,
     });
   }
@@ -356,7 +369,6 @@ export const ExportButton: React.FC<SProps> = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
   const argTypes = useRef({});
-  const args = useRef({});
 
   useChannel({
     [SET_AUTH]: (isAuth) => {
@@ -381,8 +393,6 @@ export const ExportButton: React.FC<SProps> = () => {
   const state = useStorybookState();
 
   argTypes.current = useArgTypes();
-  const [values] = useArgs();
-  args.current = values;
 
   // Export button click trigger (triggered only in the main thread)
   const handleExportClick = (action: string) => {
@@ -407,11 +417,7 @@ export const ExportButton: React.FC<SProps> = () => {
         try {
           api.selectStory(storyId);
 
-          const storyPayload = await getStoryPayload(
-            api,
-            args,
-            argTypes.current
-          );
+          const storyPayload = await getStoryPayload(api, argTypes.current);
 
           if (storyPayload.variants.length === 0) {
             return;
@@ -440,11 +446,7 @@ export const ExportButton: React.FC<SProps> = () => {
       for (const story of stories) {
         try {
           api.selectStory(story.id);
-          const storyPayload = await getStoryPayload(
-            api,
-            args,
-            argTypes.current
-          );
+          const storyPayload = await getStoryPayload(api, argTypes.current);
 
           if (storyPayload.variants.length === 0) {
             continue;

--- a/src/utils/argsQuery.ts
+++ b/src/utils/argsQuery.ts
@@ -1,0 +1,90 @@
+import { isPlainObject } from 'lodash';
+import deepEqual from 'fast-deep-equal';
+import qs, { IStringifyOptions } from 'qs';
+
+export const buildArgsParam = (initialArgs: any, args: any): string => {
+  const update = deepDiff(initialArgs, args);
+  if (!update || update === DEEPLY_EQUAL) return '';
+
+  const object = Object.entries(update).reduce((acc, [key, value]) => {
+    if (validateArgs(key, value)) return Object.assign(acc, { [key]: value });
+
+    return acc;
+  }, {});
+
+  console.log(object);
+
+  return qs
+    .stringify(encodeSpecialValues(object), QS_OPTIONS)
+    .replace(/ /g, '+')
+    .split(';')
+    .map((part: string) => part.replace('=', ':'))
+    .join(';');
+};
+
+export const QS_OPTIONS: IStringifyOptions = {
+  encode: false, // we handle URL encoding ourselves
+  delimiter: ';', // we don't actually create multiple query params
+  allowDots: true, // encode objects using dot notation: obj.key=val
+  format: 'RFC1738', // encode spaces using the + sign
+  serializeDate: (date: Date) => `!date(${date.toISOString()})`,
+};
+const VALIDATION_REGEXP = /^[a-zA-Z0-9 _-]*$/;
+const NUMBER_REGEXP = /^-?[0-9]+(\.[0-9]+)?$/;
+export const DEEPLY_EQUAL = Symbol('Deeply equal');
+const HEX_REGEXP = /^#([a-f0-9]{3,4}|[a-f0-9]{6}|[a-f0-9]{8})$/i;
+const COLOR_REGEXP = /^(rgba?|hsla?)\(([0-9]{1,3}),\s?([0-9]{1,3})%?,\s?([0-9]{1,3})%?,?\s?([0-9](\.[0-9]{1,2})?)?\)$/i;
+export const deepDiff = (value: any, update: any): any => {
+  if (typeof value !== typeof update) return update;
+  if (deepEqual(value, update)) return DEEPLY_EQUAL;
+  if (Array.isArray(value) && Array.isArray(update)) {
+    const res = update.reduce((acc, upd, index) => {
+      const diff = deepDiff(value[index], upd);
+      if (diff !== DEEPLY_EQUAL) acc[index] = diff;
+      return acc;
+    }, new Array(update.length));
+    if (update.length >= value.length) return res;
+    return res.concat(new Array(value.length - update.length).fill(undefined));
+  }
+  if (isPlainObject(value) && isPlainObject(update)) {
+    return Object.keys({ ...value, ...update }).reduce((acc, key) => {
+      const diff = deepDiff(value?.[key], update?.[key]);
+      return diff === DEEPLY_EQUAL ? acc : Object.assign(acc, { [key]: diff });
+    }, {});
+  }
+  return update;
+};
+
+export const encodeSpecialValues = (value: unknown): any => {
+  if (value === undefined) return '!undefined';
+  if (value === null) return '!null';
+  if (typeof value === 'string') {
+    if (HEX_REGEXP.test(value)) return `!hex(${value.slice(1)})`;
+    if (COLOR_REGEXP.test(value)) return `!${value.replace(/[\s%]/g, '')}`;
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(encodeSpecialValues);
+  if (isPlainObject(value)) {
+    return Object.entries(value).reduce(
+      (acc, [key, val]) => Object.assign(acc, { [key]: encodeSpecialValues(val) }),
+      {}
+    );
+  }
+  return value;
+};
+
+export const validateArgs = (key = '', value: unknown): boolean => {
+  if (key === null) return false;
+  if (key === '' || !VALIDATION_REGEXP.test(key)) return false;
+  if (value === null || value === undefined) return true; // encoded as `!null` or `!undefined`
+  if (value instanceof Date) return true; // encoded as modified ISO string
+  if (typeof value === 'number' || typeof value === 'boolean') return true;
+  if (typeof value === 'string') {
+    return (
+      VALIDATION_REGEXP.test(value) || NUMBER_REGEXP.test(value) || HEX_REGEXP.test(value) || COLOR_REGEXP.test(value)
+    );
+  }
+  if (Array.isArray(value)) return value.every((v) => validateArgs(key, v));
+  if (isPlainObject(value)) return Object.entries(value).every(([k, v]) => validateArgs(k, v));
+  return false;
+};

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -83,3 +83,6 @@ export const getEventHandlerAsPromise = () => {
 
 export const sleep = <T>(ms: number, returnValue: T): Promise<T> =>
   new Promise((resolve) => setTimeout(resolve, ms, returnValue));
+
+// Useful to await for the next JS event tick, that way the UI can update in the meantime
+export const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));


### PR DESCRIPTION
This PR removes the previous logic that waited for each component variant to be rendered before generating the request entry

This is one of the resulting output, which seems to be compatible with the old format

![image](https://user-images.githubusercontent.com/100688209/170980793-8f5382c4-f678-48cc-b157-64188e4e4798.png)

Let me know if you have any concerns :)
