### PR TITLE
fix: downgrade target version to es6

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "declaration": true,
     "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "target": "ESNEXT",
+    "target": "es6",
     "jsx": "react",
     "allowJs": true,
     "module": "ES2015",


### PR DESCRIPTION
Downgrading the typescript target version to es6, as it's the first version that supports vitest without breaking the storybook compilation:

![image](https://user-images.githubusercontent.com/100688209/180451471-ebce8ab0-9e4c-4c23-87a6-bb0a3227bde7.png)
