### PR TITLE
fix: handle also undefined and null properties

### DIFF
--- a/.storybook/stories/NullAndUndefined.stories.jsx
+++ b/.storybook/stories/NullAndUndefined.stories.jsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Button from "@mui/material/Button";
+
+export default {
+  title: "Example/NullAndUndefinedValues",
+  component: Button,
+  argTypes: {
+    variant: {
+      control: { type: "select" },
+      options: [null, "outlined", "contained"],
+    },
+    color: {
+      control: { type: "select" },
+      options: ["primary", "secondary", "warning", "info", "success"],
+    },
+    size: {
+      control: { type: "select" },
+      options: [undefined, "small", "medium", "large"],
+    },
+    disabled: { control: "boolean" },
+  },
+};
+
+const Template = (args) => <Button {...args}>{args.label}</Button>;
+
+export const NullAndUndefined = Template.bind({});
+NullAndUndefined.args = {
+  label: "Button",
+  variant: "contained",
+  disabled: false,
+  size: "small",
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-anima",
-  "version": "1.34.1",
+  "version": "1.34.0",
   "description": "Anima's Storybook addon for exporting components to Figma",
   "main": "dist/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook-anima",
-  "version": "1.34.0",
+  "version": "1.34.1",
   "description": "Anima's Storybook addon for exporting components to Figma",
   "main": "dist/index.js",
   "files": [

--- a/src/ExportButton.tsx
+++ b/src/ExportButton.tsx
@@ -20,7 +20,9 @@ import {
   isBoolean,
   isEmpty,
   isNil,
+  isNull,
   isString,
+  isUndefined,
   omit,
   omitBy,
   uniqBy,
@@ -309,7 +311,13 @@ const getStoryPayload = async (
     let is_default = false;
 
     variant = Object.keys(variant)
-      .filter((key) => isBoolean(variant[key]) || isString(variant[key]))
+      .filter(
+        (key) =>
+          isBoolean(variant[key]) ||
+          isString(variant[key]) ||
+          isUndefined(variant[key]) ||
+          isNull(variant[key])
+      )
       .reduce((cur, key) => {
         return Object.assign(cur, { [key]: variant[key] });
       }, {});


### PR DESCRIPTION
This PR fixes a bug that occurred when a component explicitly defined `select` values to contain `null` or `undefined`. In such cases, the generated components were missing variant values, thus making them invalid in Figma

Relates to: https://app.asana.com/0/1202605383971448/1202622147432257/f